### PR TITLE
Remove leading whitespace in definition of watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-ts": "./node_modules/.bin/tsc",
     "build-app": "npm-run-all build-ts app-bundle",
     "build-lib": "npm-run-all libs-bundle",
-    "watch": " ./node_modules/.bin/nodemon -V -w src --ext \".ts\" --exec \"npm run build-app\"",
+    "watch": "./node_modules/.bin/nodemon -V -w src --ext \".ts\" --exec \"npm run build-app\"",
     "serve": "./node_modules/.bin/http-server -c-1 .",
     "start": "npm-run-all build-ts build-lib  -p watch serve "
   },


### PR DESCRIPTION
The space at the start of the watch script definition causes an error when running in a Windows environment
